### PR TITLE
调整模板字符串处理

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,5 +22,5 @@ you can only translate by right click `BLi18n` or `cmd+shift+i` after select tex
 
 right click  to BLTranslate or `cmd+i` (ctrl + i )  
 selected text like `你好` will formatted to `i18nConfigGlobal.t('${appTranslateKey}')`, the extension will find the word in all language file. if it exists,  appTranslateKey is the word key, if not , it will write a new word key to corresponding files first.  
-like '{user}, 你好' will formatted to `i18nConfigGlobal.w('${appTranslateKey}', { user: })`, so you can put the variables in second param.
+like ``` `${user}, 你好` ``` will be formatted to `i18nConfigGlobal.w('${appTranslateKey}', { user })` with the default param `user` put in already.
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -211,8 +211,8 @@ export function activate(context: vscode.ExtensionContext) {
         const matchs = text.match(/(\${[^\${}]*})/g);
         let lastStr = "";
         if (matchs) {
-          lastStr = `,{${matchs.map(v => v.slice(2, -1)).join(", ")}}`;
-          replaceText = `i18nConfigGlobal.w('${appTranslateKey}'${lastStr})`;
+          lastStr = `{${matchs.map((v) => v.slice(2, -1)).join(", ")}}`;
+          replaceText = `i18nConfigGlobal.w('${appTranslateKey}', ${lastStr})`;
         } else {
           replaceText = `i18nConfigGlobal.t('${appTranslateKey}')`;
         }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -153,10 +153,7 @@ export function activate(context: vscode.ExtensionContext) {
         const matchs = text.match(/(\${[^\${}]*})/g);
         let lastStr = "";
         if (matchs) {
-          const variables = matchs.map(v =>
-            v.replace("${", "").replace("}", "")
-          );
-          lastStr = `,{${variables.map(v => `${v}: `).join(",")}}`;
+          lastStr = `,{${matchs.map(v => v.slice(2, -1)).join(", ")}}`;
           replaceText = `i18nConfigGlobal.w('${appTranslateKey}'${lastStr})`;
         } else {
           replaceText = `i18nConfigGlobal.t('${appTranslateKey}')`;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -209,10 +209,10 @@ export function activate(context: vscode.ExtensionContext) {
       if (pkg.name === "gc_native") {
         const appTranslateKey = handleAppFormat(text);
         const matchs = text.match(/(\${[^\${}]*})/g);
-        let lastStr = "";
         if (matchs) {
-          lastStr = `{${matchs.map((v) => v.slice(2, -1)).join(", ")}}`;
-          replaceText = `i18nConfigGlobal.w('${appTranslateKey}', ${lastStr})`;
+          replaceText = `i18nConfigGlobal.w('${appTranslateKey}', {${matchs
+            .map((v) => v.slice(2, -1))
+            .join(", ")}})`;
         } else {
           replaceText = `i18nConfigGlobal.t('${appTranslateKey}')`;
         }


### PR DESCRIPTION
例如 README 里的 ``` `${user}, 你好` ```，处理成 ```i18nConfigGlobal.w('${appTranslateKey}', { user })``` 可能更方便，因为 `user` 本来已经有值了，可以直接填进 `{ user }`。